### PR TITLE
중복 헤더 이슈 해결

### DIFF
--- a/api-gateway/src/main/java/scdy/apigateway/common/config/JwtFilter.java
+++ b/api-gateway/src/main/java/scdy/apigateway/common/config/JwtFilter.java
@@ -78,8 +78,8 @@ public class JwtFilter implements WebFilter {
                 public HttpHeaders getHeaders() {
                     HttpHeaders headers = new HttpHeaders();
                     headers.addAll(super.getHeaders());
-                    headers.add("X-Authenticated-User", String.valueOf(userId));
-                    headers.add("X-User-Role", userRole);
+                    headers.set("X-Authenticated-User", String.valueOf(userId));
+                    headers.set("X-User-Role", userRole);
                     return headers;
                 }
             };


### PR DESCRIPTION
## 📄 Summary
> 헤더 'userRole' 값이 중복으로 들어가는 이슈를 해결

## 🙋🏻 More
> 헤더에 .add로 값을 추가하던 것을 .set으로 수정하여 중복 값이 들어가지 않도록 수정함.
로그를 찍어보면 mutateRequest를 생성하는 과정이 12회 가량 호출되며 헤더를 여러번 설정하는 현상이 확인됨.
따라서 위 방식을 사용해 중복값이 적용되지 않도록 수정함.

## ✨issue
> this closes #14 