### PR TITLE
feat: 이미지 조회 및 삭제 로직 구현(#33)

### DIFF
--- a/config-service/src/main/java/scdy/configservice/Exception/ImageNotFoundException.java
+++ b/config-service/src/main/java/scdy/configservice/Exception/ImageNotFoundException.java
@@ -1,0 +1,9 @@
+package scdy.configservice.Exception;
+
+import scdy.configservice.common.exceptions.NotFoundException;
+
+public class ImageNotFoundException extends NotFoundException {
+    public ImageNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/config-service/src/main/java/scdy/configservice/controller/ImageController.java
+++ b/config-service/src/main/java/scdy/configservice/controller/ImageController.java
@@ -10,6 +10,8 @@ import scdy.configservice.dto.ImageResponseDto;
 import scdy.configservice.service.ImageService;
 import scdy.configservice.service.S3ImageService;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/images")
@@ -18,19 +20,63 @@ public class ImageController {
     private final ImageService imageService;
     private final S3ImageService s3ImageService;
 
+    //이미지 업로드
     @PostMapping("/upload")
     public ResponseEntity<ApiResponse<ImageResponseDto>> uploadImage(
             @RequestPart(value = "image", required = false) MultipartFile image,
             @RequestPart("imageRequestDto") ImageRequestDto imageRequestDto
     ) {
+
         ImageResponseDto dto = imageService.upload(image, imageRequestDto);
         return ResponseEntity.ok(ApiResponse.success("이미지가 업로드 되었습니다.",dto));
     }
 
-    @GetMapping("/delete")
-    public ResponseEntity<ApiResponse<Void>> deleteImage(@RequestParam String imagePath) {
-        s3ImageService.deleteImageFromS3(imagePath);
-        return ResponseEntity.ok(ApiResponse.success("이미지가 삭제되었습니다.",null));
+    // 단일 이미지 삭제
+    @DeleteMapping("/{imageId}")
+    public ResponseEntity<ApiResponse<Void>> deleteImageById(@PathVariable Long imageId) {
+
+        imageService.deleteImageById(imageId);
+        return ResponseEntity.ok(ApiResponse.success("이미지 삭제가 완료되었습니다.", null));
+    }
+
+    // 게시글에 속한 모든 이미지 삭제
+    @DeleteMapping("/board/{boardId}")
+    public ResponseEntity<ApiResponse<Void>> deleteImagesByBoardId(@PathVariable Long boardId) {
+
+        imageService.deleteImagesByBoardId(boardId);
+        return ResponseEntity.ok(ApiResponse.success("게시글 이미지가 삭제되었습니다.", null));
+    }
+
+    // 콘텐츠에 속한 모든 이미지 삭제
+    @DeleteMapping("/contents/{contentsId}")
+    public ResponseEntity<ApiResponse<Void>> deleteImagesByContentsId(@PathVariable Long contentsId) {
+
+        imageService.deleteImagesByContentsId(contentsId);
+        return ResponseEntity.ok(ApiResponse.success("콘텐츠 이미지가 삭제되었습니다.", null));
+    }
+
+    // 이미지 조회 - 사용자 프로필
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<ApiResponse<ImageResponseDto>> getUserProfile(@PathVariable Long userId) {
+
+        ImageResponseDto dto = imageService.getUserProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success("사용자 프로필 이미지를 불러왔습니다.", dto));
+    }
+
+    // 이미지 조회 - 게시글 별
+    @GetMapping("/board/{boardId}")
+    public ResponseEntity<ApiResponse<List<ImageResponseDto>>> getImagesByBoardId(@PathVariable Long boardId) {
+
+        List<ImageResponseDto> dtoList = imageService.getImagesByBoardId(boardId);
+        return ResponseEntity.ok(ApiResponse.success("게시글 이미지를 불러왔습니다.", dtoList));
+    }
+
+    // 이미지 조회 - 콘텐츠 별
+    @GetMapping("/contents/{contentsId}")
+    public ResponseEntity<ApiResponse<List<ImageResponseDto>>> getImagesByContentsId(@PathVariable Long contentsId) {
+
+        List<ImageResponseDto> dtoList = imageService.getImagesByContentsId(contentsId);
+        return ResponseEntity.ok(ApiResponse.success("콘텐츠 이미지를 불러왔습니다.", dtoList));
     }
 
 }

--- a/config-service/src/main/java/scdy/configservice/entity/DeletedImageLog.java
+++ b/config-service/src/main/java/scdy/configservice/entity/DeletedImageLog.java
@@ -1,0 +1,38 @@
+package scdy.configservice.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class DeletedImageLog {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private String s3Key;
+
+    @Column(nullable = false)
+    private LocalDateTime deletionRequestedAt;
+
+    private int retryCount = 0;
+
+
+    public DeletedImageLog(String s3Key) {
+        this.s3Key = s3Key;
+        this.deletionRequestedAt = LocalDateTime.now();
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+
+}

--- a/config-service/src/main/java/scdy/configservice/entity/Image.java
+++ b/config-service/src/main/java/scdy/configservice/entity/Image.java
@@ -28,6 +28,9 @@ public class Image {
     private String imageUrl;
 
     @Column(nullable = false)
+    private String s3Key;
+
+    @Column(nullable = false)
     private int imageSize;
 
     @Builder
@@ -36,12 +39,14 @@ public class Image {
                  Long boardId,
                  Long contentsId,
                  String imageUrl,
+                 String s3Key,
                  int imageSize) {
         this.imageType = imageType;
         this.userId = userId;
         this.boardId = boardId;
         this.contentsId = contentsId;
         this.imageUrl = imageUrl;
+        this.s3Key = s3Key;
         this.imageSize = imageSize;
     }
 

--- a/config-service/src/main/java/scdy/configservice/repository/DeletedImageLogRepository.java
+++ b/config-service/src/main/java/scdy/configservice/repository/DeletedImageLogRepository.java
@@ -1,0 +1,8 @@
+package scdy.configservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scdy.configservice.entity.DeletedImageLog;
+
+public interface DeletedImageLogRepository extends JpaRepository<DeletedImageLog, Long> {
+
+}

--- a/config-service/src/main/java/scdy/configservice/repository/ImageRepository.java
+++ b/config-service/src/main/java/scdy/configservice/repository/ImageRepository.java
@@ -3,6 +3,14 @@ package scdy.configservice.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import scdy.configservice.entity.Image;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
+    Optional<Image> findByUserId(Long userId);
+
+    List<Image> findAllByBoardId(Long boardId);
+
+    List<Image> findAllByContentsId(Long contentsId);
 }

--- a/config-service/src/main/java/scdy/configservice/service/ImageInfoService.java
+++ b/config-service/src/main/java/scdy/configservice/service/ImageInfoService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import scdy.configservice.Exception.ImageNotFoundException;
 import scdy.configservice.Exception.S3Exception;
 import scdy.configservice.dto.ImageRequestDto;
 import scdy.configservice.dto.ImageResponseDto;
@@ -21,7 +22,7 @@ public class ImageInfoService {
 
     //이미지 정보 저장 로직
     @Transactional
-    public ImageResponseDto saveImageInfo(MultipartFile image, ImageRequestDto imageRequestDto, String s3Url) {
+    public ImageResponseDto saveImageInfo(MultipartFile image, ImageRequestDto imageRequestDto, String s3Url, String s3Key) {
 
         Image imageEntity = null;
 
@@ -31,6 +32,7 @@ public class ImageInfoService {
             imageEntity = Image.builder()
                     .imageType(imageRequestDto.getImageType())
                     .imageUrl(s3Url)
+                    .s3Key(s3Key)
                     .imageSize((int)image.getSize())
                     .userId(imageRequestDto.getUserId())
                     .boardId(imageRequestDto.getBoardId())
@@ -53,6 +55,15 @@ public class ImageInfoService {
         }
 
         return ImageResponseDto.from(imageEntity);
+    }
+
+
+    //이미지 정보 삭제 로직
+    @Transactional
+    public void deleteImageInfo(Long imageId){
+
+        Image image = imageRepository.findById(imageId).orElseThrow(() -> new ImageNotFoundException("존재하지 않는 이미지"));
+        imageRepository.delete(image);
     }
 
 }

--- a/config-service/src/main/java/scdy/configservice/service/ImageService.java
+++ b/config-service/src/main/java/scdy/configservice/service/ImageService.java
@@ -3,21 +3,29 @@ package scdy.configservice.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import scdy.configservice.Exception.ImageNotFoundException;
 import scdy.configservice.Exception.S3Exception;
 import scdy.configservice.Exception.S3keyDuplicatedException;
 import scdy.configservice.dto.ImageRequestDto;
 import scdy.configservice.dto.ImageResponseDto;
+import scdy.configservice.entity.Image;
+import scdy.configservice.repository.ImageRepository;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class ImageService {
 
+    private final ImageRepository imageRepository;
     private final S3ImageService s3ImageService;
     private final ImageValidationService imageValidationService;
     private final ImageInfoService imageInfoService;
@@ -26,7 +34,7 @@ public class ImageService {
     private static final int MAX_RETRY_COUNT = 3;
 
 
-    //이미지 저장 로직
+//이미지 저장 로직
     public ImageResponseDto upload(MultipartFile image, ImageRequestDto imageRequestDto) {
 
         //이미지 검증
@@ -38,7 +46,7 @@ public class ImageService {
         String s3Url = uploadToS3WithRetry(image, s3Key);
 
         //이미지 정보 업로드
-        return imageInfoService.saveImageInfo(image, imageRequestDto, s3Url);
+        return imageInfoService.saveImageInfo(image, imageRequestDto, s3Url, s3Key);
     }
 
 
@@ -138,9 +146,118 @@ public class ImageService {
         );
     }
 
+
+    //사용자 프로필 이미지 조회
+    @Transactional(readOnly = true)
+    public ImageResponseDto getUserProfile(Long userId){
+
+        Image image = imageRepository.findByUserId(userId).orElseThrow(
+                () -> new ImageNotFoundException("존재하지 않는 이미지입니다."));
+
+        return ImageResponseDto.from(image);
+    }
+
+    // 이미지 엔티티 리스트를 DTO 리스트로 변환하는 공통 로직
+    private List<ImageResponseDto> toImageResponseDtoList(List<Image> imageList) {
+
+        return imageList.stream()
+                .map(ImageResponseDto::from)
+                .toList();
+    }
+
+    // 게시글 별 이미지 목록 조회
+    @Transactional(readOnly = true)
+    public List<ImageResponseDto> getImagesByBoardId(Long boardId) {
+
+        List<Image> imageList = imageRepository.findAllByBoardId(boardId);
+
+        return toImageResponseDtoList(imageList);
+    }
+
+    // 콘텐츠 별 이미지 목록 조회
+    @Transactional(readOnly = true)
+    public List<ImageResponseDto> getImagesByContentsId(Long contentsId) {
+
+        List<Image> imageList = imageRepository.findAllByContentsId(contentsId);
+
+        return toImageResponseDtoList(imageList);
+    }
+
+
+//이미지 삭제
     //이미지 삭제 시 정합성(DB 먼저 삭제 후 s3에서 삭제.)
+    //단일 이미지 삭제
+    public void deleteImageById(Long imageId) {
+
+        Image image = imageRepository.findById(imageId).orElseThrow(() -> new ImageNotFoundException("존재하지 않는 이미지"));
+        String s3Key = image.getS3Key();
+
+        //DB에서 이미지 삭제
+        imageInfoService.deleteImageInfo(imageId);
+        log.info("DB에서 이미지 정보 삭제 완료. s3Key: {}", s3Key);
+
+        //S3에서 이미지 삭제
+        try{
+            s3ImageService.deleteImageFromS3(s3Key);
+            log.info("S3에서 이미지 파일 삭제 성공. s3Key: {}", s3Key);
+        }catch (Exception e){
+            s3ImageService.saveDeleteErrorLog(s3Key);
+        }
+    }
 
 
-    //(S3 삭제 실패 시 주기적 검사로 처리)
+    //복수 이미지 삭제(게시글 및 콘텐츠)
+
+    // 게시글 ID로 다중 이미지 삭제
+    @Transactional
+    public void deleteImagesByBoardId(Long boardId) {
+
+        List<Image> imagesToDelete = imageRepository.findAllByBoardId(boardId);
+
+        if (imagesToDelete.isEmpty()) {
+            log.info("게시글 ID {}에 연결된 이미지가 없어 삭제를 건너뜁니다.", boardId);
+            return;
+        }
+
+        deleteImagesAndHandleS3(imagesToDelete, "게시글", boardId);
+    }
+
+    // 콘텐츠 ID로 다중 이미지 삭제
+    @Transactional
+    public void deleteImagesByContentsId(Long contentsId) {
+
+        List<Image> imagesToDelete = imageRepository.findAllByContentsId(contentsId);
+
+        if (imagesToDelete.isEmpty()) {
+            log.info("콘텐츠 ID {}에 연결된 이미지가 없어 삭제를 건너뜁니다.", contentsId);
+            return;
+        }
+
+        deleteImagesAndHandleS3(imagesToDelete, "콘텐츠", contentsId);
+    }
+
+    private void deleteImagesAndHandleS3(List<Image> images, String type, Long id) {
+
+        //이미지 정보 삭제
+        List<String> s3Keys = images.stream()
+                .map(Image::getS3Key)
+                .toList();
+
+        imageRepository.deleteAllInBatch(images);
+        log.info("DB에서 {} ID {}의 이미지 {}개 정보 삭제 완료.", type, id, images.size());
+
+        // S3에서 이미지 파일 삭제
+        for (String s3Key : s3Keys) {
+            try {
+                s3ImageService.deleteImageFromS3(s3Key);
+                log.info("S3에서 이미지 파일 삭제 성공. s3Key: {}", s3Key);
+            } catch (Exception e) {
+                log.error("S3에서 이미지 파일 삭제 실패. s3Key: {}: {}", s3Key, e.getMessage());
+                s3ImageService.saveDeleteErrorLog(s3Key);
+            }
+        }
+    }
+
+    //TODO:(S3 삭제 실패 시 주기적 검사로 처리)
 
 }

--- a/config-service/src/main/java/scdy/configservice/service/S3ImageService.java
+++ b/config-service/src/main/java/scdy/configservice/service/S3ImageService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import scdy.configservice.Exception.FileSizeOverException;
 import scdy.configservice.Exception.S3Exception;
+import scdy.configservice.entity.DeletedImageLog;
+import scdy.configservice.repository.DeletedImageLogRepository;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -34,8 +36,8 @@ import java.util.UUID;
 @Service
 public class S3ImageService {
 
-    //TODO: 고아객체 검증 추가
     private final AmazonS3 amazonS3;
+    private final DeletedImageLogRepository deletedImageLogRepository;
 
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
@@ -88,10 +90,10 @@ public class S3ImageService {
     }
 
     //이미지 삭제
-    public void deleteImageFromS3(String imageAddress){
-        String key = getKeyFromImageAddress(imageAddress);
+    public void deleteImageFromS3(String s3Key){
+
         try{
-            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, s3Key));
         }catch (Exception e){
             throw new S3Exception("이미지 삭제 실패");
         }
@@ -99,6 +101,7 @@ public class S3ImageService {
 
 
     private String getKeyFromImageAddress(String imageAddress){
+
         try{
             URL url = new URL(imageAddress);
             String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
@@ -109,6 +112,7 @@ public class S3ImageService {
     }
 
     public boolean doesImageExist(String S3Key){
+
         try{
             return amazonS3.doesObjectExist(bucketName, S3Key);
         }catch (Exception e){
@@ -116,5 +120,15 @@ public class S3ImageService {
             throw new S3Exception("S3 연결 오류 발생");
         }
     }
+
+    //이미지 삭제 오류 로그 저장
+    @Transactional
+    public void saveDeleteErrorLog(String S3Key){
+
+        DeletedImageLog deletedImageLog = new DeletedImageLog(S3Key);
+        deletedImageLogRepository.save(deletedImageLog);
+    }
+
+
 
 }

--- a/notification-service/src/main/java/scdy/notificationservice/service/RabbitMQProducer.java
+++ b/notification-service/src/main/java/scdy/notificationservice/service/RabbitMQProducer.java
@@ -1,34 +1,10 @@
 package scdy.notificationservice.service;
 
-<<<<<<< HEAD
-=======
 import lombok.RequiredArgsConstructor;
->>>>>>> 708159e71076ffc1d4541690aeb6d925af928afb
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-<<<<<<< HEAD
-import scdy.notificationservice.dto.NotificationRequestDto;
-import scdy.notificationservice.entity.Notification;
-import scdy.notificationservice.repository.NotificationRepository;
-
-@Slf4j
-@Service
-public class RabbitMQProducer {
-    private final RabbitTemplate rabbitTemplate;
-    private final NotificationRepository notificationRepository;
-
-
-    public RabbitMQProducer(RabbitTemplate rabbitTemplate, NotificationRepository notificationRepository) {
-        this.rabbitTemplate = rabbitTemplate;
-        this.notificationRepository = notificationRepository;
-    }
-
-    @Transactional
-    public NotificationRequestDto sendNotification(NotificationRequestDto notificationDto) {
-        Notification notification = Notification.builder()
-=======
 import scdy.notificationservice.dto.NotificationDto;
 import scdy.notificationservice.entity.Notification;
 import scdy.notificationservice.repository.NotificationRepository;
@@ -49,7 +25,6 @@ public class RabbitMQProducer {
 
     public NotificationDto sendNotification(NotificationDto notificationDto){
         Notification notification =  Notification.builder()
->>>>>>> 708159e71076ffc1d4541690aeb6d925af928afb
                 .userId(notificationDto.getUserId())
                 .noticeContents(notificationDto.getNoticeContents())
                 .noticedAt(notificationDto.getNoticedAt())
@@ -57,19 +32,9 @@ public class RabbitMQProducer {
                 .build();
         notificationRepository.save(notification);
 
-<<<<<<< HEAD
-        // NotificationDto를 전송하여 타입 일관성 유지
-        rabbitTemplate.convertAndSend("NotificationExchange", "key", notificationDto);
-
-        log.info("Send Notification : {}", notificationDto.toString());
-        return notificationDto;
-    }
-}
-=======
         rabbitTemplate.convertAndSend("notificationQueue", notification);
 
         log.info("Send Notification : {}", notificationDto.toString());
         return NotificationDto.from(notification);
     }
 }
->>>>>>> 708159e71076ffc1d4541690aeb6d925af928afb

--- a/user-service/src/main/java/scdy/userservice/service/UserService.java
+++ b/user-service/src/main/java/scdy/userservice/service/UserService.java
@@ -32,6 +32,7 @@ public class UserService {
 
     @Transactional
     public UserResponseDto signUp(UserRequestDto userRequestDto) {
+
         if(userRepository.existsByEmail(userRequestDto.getEmail())) {
             throw new DuplicateUserException("이미 가입된 유저입니다.");
         }
@@ -49,8 +50,8 @@ public class UserService {
         return UserResponseDto.from(user);
     }
 
-    @Transactional
     public String login(UserRequestDto userRequestDto) {
+
         User user = userRepository.findByEmail(userRequestDto.getEmail())
                 .orElseThrow(()->new UserNotFoundException("유저를 찾을 수 없습니다."));
 
@@ -71,6 +72,7 @@ public class UserService {
     }
 
     public String logout(String accessToken) {
+
         String email = jwtUtils.getUserIdFromToken(accessToken);
         // 리프레시 토큰 삭제
         redisTemplate.delete("RT:" + email);
@@ -90,6 +92,7 @@ public class UserService {
 
     @Transactional
     public UserResponseDto updateUser(Long userId,UserRequestDto userRequestDto) {
+
         String newPassword = null;
         User user = userRepository.findById(userId)
                 .orElseThrow(()->new UserNotFoundException("유저를 찾을수 없습니다."));
@@ -107,7 +110,7 @@ public class UserService {
     @Transactional
     public void deleteUser(Long userId, String password) {
         User user = userRepository.findById(userId)
-                .orElseThrow(()->new PasswordNotMatchException("유저를 찾을수 없습니다"));
+                .orElseThrow(()->new UserNotFoundException("유저를 찾을수 없습니다"));
         if(!passwordEncoder.matches(password,user.getPassword())){
             throw new PasswordNotMatchException("비밀번호가 일치 하지않습니다.");
         }
@@ -123,11 +126,13 @@ public class UserService {
 
     @Cacheable(value = "userById", key = "#id", cacheManager = "redisCacheManager")
     public UserResponseDto findById(Long userId) {
+
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("유저를 찾을 수 없습니다"));
         return UserResponseDto.from(user);
     }
 
     public List<UserResponseDto> findAll() {
+
         List<User> users = userRepository.findAll();
 
         // User 엔티티 리스트를 UserResponseDto 리스트로 변환
@@ -135,6 +140,5 @@ public class UserService {
                 .map(UserResponseDto::from) // UserResponseDto.from(User user) 메서드 사용
                 .toList();
     }
-
 
 }


### PR DESCRIPTION
## 📄 Summary
> 이미지 조회 및 삭제 로직을 구현하였습니다.

## 🙋🏻 More
> 이미지 정보와 s3 이미지 서비스 로직을 분리하여 정합성을 유지하도록 하였으며, 정보 서비스에만 트랜잭션을 적용하여 불필요한 대기 및 타임아웃이 발생하지 않도록 작성.

## ✨issue
> this closes issue #33